### PR TITLE
DB_design_README_creste

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ Things you may want to cover:
 |Column|Type|Options|
 |------|----|-------|
 |nickname|cher(255)|null: false|
-|group_id|integer|null: false, foreign_key: true|
 
 ### Association
 - has_many :messages
+- has_many :groups_users
 - has_many :groups, through: :groups_users
 -----------------------------------------------------
 
@@ -43,10 +43,10 @@ Things you may want to cover:
 Column|Type|Options|
 |------|----|-------|
 |room_name|cher(255)|null: false|
-|user_id|integer|null: false, foreign_key: true|
 
 ### Association
 - has_many :messages
+- has_many :groups_users
 - has_many :users, through: :groups_users
 -----------------------------------------------------
 
@@ -56,8 +56,8 @@ Column|Type|Options|
 |------|----|-------|
 |body|text| |
 |image|string| |
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
+|user_id|references|null: false, foreign_key: true|
+|group_id|references|null: false, foreign_key: true|
 
 
 ### Association
@@ -69,8 +69,8 @@ Column|Type|Options|
 
 |Column|Type|Options|
 |------|----|-------|
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
+|user_id|references|null: false, foreign_key: true|
+|group_id|references|null: false, foreign_key: true|
 
 ### Association
 

--- a/README.md
+++ b/README.md
@@ -22,3 +22,58 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+
+# ChatSpace_DB_design
+
+## usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|nickname|cher(255)|null: false|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+- has_many :messages
+- has_many :groups, through: :groups_users
+-----------------------------------------------------
+
+##groupsテーブル
+
+Column|Type|Options|
+|------|----|-------|
+|room_name|cher(255)|null: false|
+|user_id|integer|null: false, foreign_key: true|
+
+### Association
+- has_many :messages
+- has_many :users, through: :groups_users
+-----------------------------------------------------
+
+## messagesテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|body|text| |
+|image|string| |
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+
+### Association
+- belongs_to :user
+- belongs_to :group
+-----------------------------------------------------
+
+## groups_usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+
+- belongs_to :user
+- belongs_to :group
+-----------------------------------------------------


### PR DESCRIPTION
# Why
- chatspaceのテーブル設計の内容と、エンティティ同士の関係性を明確化するため
# What
- READMEにデータベースの設計図を記載
- users, groups, messagesテーブル, groups_users中間テーブルを定義
- users：groupsは多対多、users：messagesは１対多、groups,：messagesは１対多のリレーションを定義
- 各エンティティの属性をカラムに落とし込んだ














