### PR TITLE
chatspaceのフロントの開発

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,4 +52,6 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
+gem 'font-awesome-sass', '~> 5.9.0'
+
 gem 'haml-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,6 +54,8 @@ GEM
     erubis (2.7.0)
     execjs (2.7.0)
     ffi (1.11.1)
+    font-awesome-sass (5.9.0)
+      sassc (>= 1.11)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     haml (5.1.2)
@@ -138,6 +140,8 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    sassc (2.2.0)
+      ffi (~> 1.9)
     sexp_processor (4.12.1)
     spring (2.1.0)
     spring-watcher-listen (2.0.1)
@@ -176,6 +180,7 @@ PLATFORMS
 DEPENDENCIES
   byebug
   coffee-rails (~> 4.2)
+  font-awesome-sass (~> 5.9.0)
   haml-rails
   jbuilder (~> 2.5)
   jquery-rails

--- a/app/assets/stylesheets/_variable.scss
+++ b/app/assets/stylesheets/_variable.scss
@@ -1,0 +1,11 @@
+$sub_menu_pad: 0 20px;
+$main_menu_pad: 0 40px;
+
+$header_hight: 100px;
+
+$dark_blue: #253141;
+$navy_blue: #2f3e51;
+$light_blue: #38AEF0;
+$light_gray: #999999;
+
+$white_character: #FFF;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,1 +1,10 @@
 @import "./reset";
+
+@import "font-awesome-sprockets";
+@import "font-awesome";
+
+@import "_variable.scss";
+
+@import "./group-create-alarm.scss";
+@import "./sub_menu";
+@import "./index";

--- a/app/assets/stylesheets/group-create-alarm.scss
+++ b/app/assets/stylesheets/group-create-alarm.scss
@@ -1,0 +1,7 @@
+.group-create-alarm{
+  background-color: #38AEF0;
+  color: white;
+  width: 100vw;
+  text-align: center;
+  float: left;
+}

--- a/app/assets/stylesheets/index.scss
+++ b/app/assets/stylesheets/index.scss
@@ -1,0 +1,113 @@
+html, body {
+  height: 100%;
+  box-sizing: border-box;
+}
+
+.main-manu{
+  width: calc(100vw - 300px);
+  min-height: 300px;
+  padding-left : 300px;
+  // position: fixed;
+
+
+  &__current-group{
+    border-bottom: thin solid #eeeeee;
+    box-sizing: border-box;
+    padding: $main_menu_pad;
+    height: $header_hight;
+    width: calc(100vw - 300px);
+  }
+  &__current-group-name{
+    color: #333333;
+    font-size: 20px;
+    padding: 35px 0 0;
+  }
+  &__current-group-member{
+    color: $light_gray;
+    font-size: 12px;
+    padding: 15px 0 0;
+  }
+  &__current-group-edit-btn{
+    color: $light_blue;
+    border: solid 1px $light_blue;
+    line-height: 40px;
+    height: 40px;
+    padding: 0 20px;
+    position: absolute;
+    top: 28px;
+    right: 40px;
+    margin: auto;
+  }
+  &__message{
+    background-color: #fafafa;
+    box-sizing: border-box;
+    padding-top: 6px;
+    padding: $main_menu_pad;
+    height: calc(100vh - 100px - 90px);
+    overflow: scroll;
+  }
+  &__message::-webkit-scrollbar{
+    display:none;
+  }
+  &__one-message{
+    background-color: #fafafa;
+    padding: 40px 0 0;
+  }
+  &__one-message-user{
+    display: flex;
+  }
+  &__one-message-name{
+    color: #434A54;
+    font-size: 16px;
+    font-weight: bold;
+  }
+  &__one-message-time{
+    color: $light_gray;
+    font-size: 12px;
+    padding: 0 0 0 10px;
+  }
+  &__one-message-detail{
+    color: #434A54;
+    font-size: 14px;
+    clear: none;
+    padding: 10px 0 0;
+  }
+  &__submission{
+    background-color: #ddd;
+    box-sizing: border-box;
+    padding: 20px 40px;
+    width: calc(100vw - 300px);
+    height: 90px;
+  }
+  &__submission-form{
+    display: flex;
+    justify-content: space-between;
+  }
+  &__submission-form-box{
+    width: 100%;
+    position: relative;
+  }
+  &__submission-form-text{
+    padding: 0 10px;
+    border: 0px;
+    height: 50px;
+    width: 100%;
+    box-sizing: border-box;
+  }
+  &__submission-form-image{
+    font-size: 1.4rem;
+    position: absolute;
+    top: 10px;
+    right: 10px;
+  }
+  &__submission-form-image-upload{
+    display:none;
+  }
+  &__submission-form-submit{
+    background-color: $light_blue;
+    color: $white_character;
+    border: 0px;
+    margin-left: 15px;
+    padding: 0 30px;
+  }
+}

--- a/app/assets/stylesheets/sub_menu.scss
+++ b/app/assets/stylesheets/sub_menu.scss
@@ -1,0 +1,58 @@
+.sub-menu{
+  width: 300px;
+  float: left;
+  position: relative;
+  z-index: 2;
+
+  &__my-profile{
+    background-color: $dark_blue;
+    color: $white_character;
+    font-size: 16px;
+    box-sizing: border-box;
+    height: $header_hight;
+    padding: $sub_menu_pad;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+  &__my-mane{
+    font-weight: bold;
+  }
+  &__edit{
+    display: flex;
+
+  }
+  &__group-create{
+    margin-left: 0.3rem;
+  }
+  &__account-edit{
+    margin-left: 0.3rem;
+  }
+  a{
+    color: inherit
+  }
+
+  &__group-list{
+    background-color: $navy_blue;
+    box-sizing: border-box;
+    height: calc(100vh - 100px);
+    width: 300px;
+    padding: $sub_menu_pad;
+    overflow: scroll;
+  }
+  &__group-list::-webkit-scrollbar{
+    display:none;
+  }
+  &__one-group{
+    padding: 20px 0 20px;
+  }
+  &__one-group-name{
+    color: $white_character;
+    font-size: 15px;
+    padding: 0 0 5px;
+  }
+  &__one-group-message{
+    color: $white_character;
+    font-size: 11px;
+  }
+}

--- a/app/views/message/_one_group.html.haml
+++ b/app/views/message/_one_group.html.haml
@@ -1,0 +1,5 @@
+%div.sub-menu__one-group
+  %div.sub-menu__one-group-name
+    グループ１
+  %div.sub-menu__one-group-message
+    最新のメッセージ１

--- a/app/views/message/_one_message.html.haml
+++ b/app/views/message/_one_message.html.haml
@@ -1,0 +1,8 @@
+%div.main-manu__one-message
+%ul.main-manu__one-message-user
+  %li.main-manu__one-message-name
+    送信者名
+  %li.main-manu__one-message-time
+    投稿時間
+%div.main-manu__one-message-detail
+  メッセージ

--- a/app/views/message/_sub_menu.html.haml
+++ b/app/views/message/_sub_menu.html.haml
@@ -1,0 +1,16 @@
+%div.mamu
+  %div.sub-menu
+    %div.sub-menu__my-profile
+      %p.sub-menu__my-mane
+        マイネーム
+      %ul.sub-menu__edit
+        %li.sub-menu__group-create
+          = link_to '' do
+            = icon('fas', 'edit')
+        %li.sub-menu__account-edit
+          = link_to '' do
+            = icon('fas', 'cog')
+
+    %div.sub-menu__group-list
+      - for num in 1..10
+        = render partial: "one_group"

--- a/app/views/message/index.html.haml
+++ b/app/views/message/index.html.haml
@@ -1,0 +1,26 @@
+= render partial: "sub_menu"
+
+%div.main-manu
+
+  %header.main-manu__current-group
+    %div.main-manu__current-group-name
+      グループ名
+    %div.main-manu__current-group-member
+      Member
+    = link_to '' do
+      %div.main-manu__current-group-edit-btn
+        Edit
+
+  %div.main-manu__message
+    - for num in 1..10
+      = render partial: "one_message"
+
+  %footer.main-manu__submission
+    %form.main-manu__submission-form-image-box{action: ''}
+      %div.main-manu__submission-form
+        %div.main-manu__submission-form-box
+          %input.main-manu__submission-form-text{type: "text", placeholder: "type a message"}
+            %label.main-manu__submission-form-image{for: "upload-icon"}
+              %i.far.fa-image
+              %input.main-manu__submission-form-image-upload#upload-icon{type: "file"}
+        %input.main-manu__submission-form-submit{type: "submit", value: "Send"}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-  root :message#index
+  root 'message#index'
 end


### PR DESCRIPTION
<img width="1440" alt="スクリーンショット 2019-08-30 20 50 16" src="https://user-images.githubusercontent.com/54523803/64018616-e1b02c00-cb67-11e9-9f13-b98df9309169.png">

# [Why]
BEMを使用し、haml/Scssでフロントを実装。
# [What]
グループ作成とアカウント編集、グループ編集をリンク化
テキストフォームに画像アイコンを重ねる
画像アイコンを押したら、ファイル選択画面が表示
Sendボタンを実装
グーループ一覧とメッセージ一覧をスクロール化
サブメニューとメインメニューのhaml/Scssをそれぞれ分割
よく使う色を変数化
各メニューの幅を変数にし、調整を一気に出来るように実装
