### PR TITLE
Wip 自動更新機能

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -50,8 +50,8 @@ $('#new_message').on('submit', function(e){
       $('.main-manu__submission-form-submit').removeAttr('disabled')
     });
   });
-  if($(".main-manu__message").lenght != 0){
-    var reloadMessages = function() {
+  var reloadMessages = function() {
+    if(document.URL.match(/messages/)) {
       var last_message_id = $(".main-manu__one-message:last").data('messageNum');
       var group_id = $(".main-manu__one-message").data('groupNum');
       $.ajax({

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,7 +1,7 @@
 $(function(){
   function buildHTML(message){
     var img = message.image ? `<img class = "main-manu__one-message-detail--image" src="${message.image}">` : '';
-    var html = `<div class = "main-manu__one-message">
+    var html = `<div class = "main-manu__one-message" data-id="${message.id}">
                   <ul class = "main-manu__one-message-user">
                     <li class = "main-manu__one-message-name">
                       ${message.name}
@@ -50,4 +50,27 @@ $('#new_message').on('submit', function(e){
       $('.main-manu__submission-form-submit').removeAttr('disabled')
     });
   });
+
+  var reloadMessages = function() {
+    //カスタムデータ属性を利用し、ブラウザに表示されている最新メッセージのidを取得
+    var last_message_id = $(".main-manu__one-message").data("one_message")
+
+    $.ajax({
+      //ルーティングで設定した通り/groups/id番号/api/messagesとなるよう文字列を書く
+      url: "/api/messages",
+      type: 'get',
+      dataType: 'json',
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      messages.forEach(function(message){
+        var insertHTML = buildHTML(message)
+        $('.main-manu__message').append(insertHTML)
+      })
+    })
+    .fail(function() {
+      console.log('error');
+    });
+  };
+  setInterval(reloadMessages, 5000);
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,7 +1,7 @@
 $(function(){
   function buildHTML(message){
     var img = message.image ? `<img class = "main-manu__one-message-detail--image" src="${message.image}">` : '';
-    var html = `<div class = "main-manu__one-message" data-id="${message.id}">
+    var html = `<div class = "main-manu__one-message" data-message-num = "${message.id}", data-group-num = "${message.group_id}">
                   <ul class = "main-manu__one-message-user">
                     <li class = "main-manu__one-message-name">
                       ${message.name}
@@ -50,27 +50,27 @@ $('#new_message').on('submit', function(e){
       $('.main-manu__submission-form-submit').removeAttr('disabled')
     });
   });
-
-  var reloadMessages = function() {
-    //カスタムデータ属性を利用し、ブラウザに表示されている最新メッセージのidを取得
-    var last_message_id = $(".main-manu__one-message").data("one_message")
-
-    $.ajax({
-      //ルーティングで設定した通り/groups/id番号/api/messagesとなるよう文字列を書く
-      url: "/api/messages",
-      type: 'get',
-      dataType: 'json',
-      data: {id: last_message_id}
-    })
-    .done(function(messages) {
-      messages.forEach(function(message){
-        var insertHTML = buildHTML(message)
-        $('.main-manu__message').append(insertHTML)
+  if($(".main-manu__message").lenght != 0){
+    var reloadMessages = function() {
+      var last_message_id = $(".main-manu__one-message:last").data('messageNum');
+      var group_id = $(".main-manu__one-message").data('groupNum');
+      $.ajax({
+        url: "/groups/"+ group_id +"/api/messages",
+        type: 'get',
+        dataType: 'json',
+        data: {id: last_message_id}
       })
-    })
-    .fail(function() {
-      console.log('error');
-    });
+      .done(function(messages) {
+        messages.forEach(function(message){
+          var insertHTML = buildHTML(message)
+          $('.main-manu__message').append(insertHTML)
+          var scroll = $('.main-manu__message')[0].scrollHeight;
+          $(`.main-manu__message`).animate({scrollTop: scroll}, 'fast')
+        })
+      })
+      .fail(function() {
+      });
+    };
   };
   setInterval(reloadMessages, 5000);
-});
+})

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -55,7 +55,7 @@ $('#new_message').on('submit', function(e){
       var last_message_id = $(".main-manu__one-message:last").data('messageNum');
       var group_id = $(".main-manu__one-message").data('groupNum');
       $.ajax({
-        url: "/groups/"+ group_id +"/api/messages",
+        url: `/groups/${group_id}/api/messages`,
         type: 'get',
         dataType: 'json',
         data: {id: last_message_id}

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,10 @@
+class Api::MessagesController < ApplicationController
+  def index
+    # ルーティングでの設定によりparamsの中にgroup_idというキーでグループのidが入るので、これを元にDBからグループを取得する
+    group = Group.find(params[:group_id])
+    # ajaxで送られてくる最後のメッセージのid番号を変数に代入
+    last_message_id = params[:id].to_i
+    # 取得したグループでのメッセージ達から、idがlast_messge_idよりも新しい(大きい)メッセージ達のみを取得
+    @messages = group.messages.includes(:user).where("id > #{last_message_id}")
+  end
+end

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,10 +1,11 @@
 class Api::MessagesController < ApplicationController
   def index
-    # ルーティングでの設定によりparamsの中にgroup_idというキーでグループのidが入るので、これを元にDBからグループを取得する
     group = Group.find(params[:group_id])
-    # ajaxで送られてくる最後のメッセージのid番号を変数に代入
     last_message_id = params[:id].to_i
-    # 取得したグループでのメッセージ達から、idがlast_messge_idよりも新しい(大きい)メッセージ達のみを取得
     @messages = group.messages.includes(:user).where("id > #{last_message_id}")
+    respond_to do |format|
+      format.html
+      format.json
+    end
   end
 end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image
+  json.created_at message.created_at
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,7 +1,7 @@
 json.array! @messages do |message|
   json.content message.content
-  json.image message.image
-  json.created_at message.created_at
-  json.user_name message.user.name
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y/%m/%d %H:%M")
+  json.name message.user.name
   json.id message.id
 end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-%div.main-manu__one-message
+%div.main-manu__one-message{data: {one_message: "#{message.id}"}}
   %ul.main-manu__one-message-user
     %li.main-manu__one-message-name
       = message.user.name

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-%div.main-manu__one-message{data: {one_message: "#{message.id}"}}
+%div.main-manu__one-message{data: {one_message: "#{message.id.to_i}", one_group: "#{message.group_id.to_i}"} }
   %ul.main-manu__one-message-user
     %li.main-manu__one-message-name
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,4 @@ json.name @message.user.name
 json.created_at @message.created_at.strftime("%Y/%m/%d %H:%M")
 json.content @message.content
 json.image @message.image.url
+json.id @message.id

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -17,7 +17,18 @@
         Edit
 
   %div.main-manu__message
-    = render @messages
+    - @messages.each do |message|
+      %div.main-manu__one-message{data: {message_num: "#{message.id.to_i}", group_num: "#{message.group_id.to_i}"} }
+        %ul.main-manu__one-message-user
+          %li.main-manu__one-message-name
+            = message.user.name
+          %li.main-manu__one-message-time
+            = message.created_at.strftime("%Y/%m/%d %H:%M")
+        %div.main-manu__one-message-detail
+          - if message.content.present?
+            %p.main-manu__one-message-detail--content
+              = message.content
+          = image_tag message.image.url, class: 'main-manu__one-message-detail--image' if message.image.present?
 
   %footer.main-manu__submission
     = form_for [@group, @message], id: 'new__message' do |f|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,4 +5,7 @@ Rails.application.routes.draw do
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
   end
+  namespace :api do
+    resources :messages, only: :index, defaults: { format: 'json' }
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,8 +4,8 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
-  end
-  namespace :api do
-    resources :messages, only: :index, defaults: { format: 'json' }
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
# Why

自動更新機能を追加することで、自分以外のユーザーがコメントした時、ブラウザを手動で更新せずに済む
# What
gif:https://gyazo.com/68aa24ee7aad5899633c776241adf7d3

1.表示されているメッセージのHTMLにid情報を追加
2.メッセージを更新するためのアクションを実装
3.追加したアクションを動かすためのルーティングを実装
4.追加したアクションをリクエストするよう実装
5.取得した最新のメッセージをブラウザのメッセージ一覧に追加
6.数秒ごとにリクエストするよう実装
7.メッセージ分だけスクロールするよう実装
8.メッセージ一覧のページでのみJSが動くよう実装